### PR TITLE
cgo: Add dl link

### DIFF
--- a/vendor/libretro/libretro.go
+++ b/vendor/libretro/libretro.go
@@ -1,6 +1,7 @@
 package libretro
 
 /*
+#cgo LDFLAGS: -ldl
 #include "libretro.h"
 #include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
Was getting the following errors when compiling...

```
/libretro/_obj/libretro.cgo2.o: In function `_cgo_7de0b1822932_Cfunc_dlopen':
libretro/libretro.go:218: undefined reference to `dlopen'
libretro/_obj/libretro.cgo2.o: In function `_cgo_7de0b1822932_Cfunc_dlsym':
libretro/libretro.go:232: undefined reference to `dlsym'
```

Adding a link to `-ldl` fixed it.