### PR TITLE
video: Start the window not fullscreen

### DIFF
--- a/go-playthemall.go
+++ b/go-playthemall.go
@@ -87,7 +87,9 @@ func coreLoadGame(filename string) {
 
 	avi := core.GetSystemAVInfo()
 
-	videoConfigure(avi.Geometry, true)
+	// Create the video window, not-fullscreen.
+	videoConfigure(avi.Geometry, false)
+
 	// Append the library name to the window title.
 	if len(si.LibraryName) > 0 {
 		window.SetTitle("playthemall - " + si.LibraryName)


### PR DESCRIPTION
Fullscreen on my monitor stops the video playback, and for some reason freezes the application. Should start it not fullscreen, and then allow the user to change it.

Later on, we could have it start fullscreen with some configuration file.