### PR TITLE
args: Mimic the command line args of RetroArch

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ On Debian or Ubuntu:
 
 ## Running
 
-    go-playthemall -L nestopia_libretro.so -G mario3.nes
+    go-playthemall -L nestopia_libretro.so mario3.nes

--- a/go-playthemall.go
+++ b/go-playthemall.go
@@ -98,8 +98,17 @@ func coreLoadGame(filename string) {
 
 func main() {
 	var corePath = flag.String("L", "", "Path to the libretro core")
-	var gamePath = flag.String("G", "", "Path to the game")
 	flag.Parse()
+	args := flag.Args()
+
+	var gamePath string
+	if len(args) > 0 {
+		gamePath = args[0]
+	}
+	if (len(*corePath) == 0 || len(gamePath) == 0) {
+		log.Fatalln("Usage: go-playthemall -L <core> <game>")
+		return
+	}
 
 	if err := glfw.Init(); err != nil {
 		log.Fatalln("failed to initialize glfw:", err)
@@ -107,7 +116,7 @@ func main() {
 	defer glfw.Terminate()
 
 	coreLoad(*corePath)
-	coreLoadGame(*gamePath)
+	coreLoadGame(gamePath)
 	menuInit()
 
 	for !window.ShouldClose() {


### PR DESCRIPTION
Having go-playthemall match the command line arguments of RetroArch allows easy switching between running RetroArch and go-playthemall.

This also comes with a nice `usage: go-playthemall -L <core> <game>` reminder.