### PR TITLE
Remove redundant switch breaks

### DIFF
--- a/environment.go
+++ b/environment.go
@@ -16,13 +16,10 @@ func environment(cmd uint32, data unsafe.Pointer) bool {
 		} else {
 			libretro.SetString(data, currentUser.Username)
 		}
-		break
 	case libretro.EnvironmentGetLogInterface:
 		core.BindLogCallback(data, nanoLog)
-		break
 	case libretro.EnvironmentGetCanDupe:
 		libretro.SetBool(data, true)
-		break
 	case libretro.EnvironmentSetPixelFormat:
 		format := libretro.GetPixelFormat(data)
 		if format > libretro.PixelFormatRGB565 {
@@ -30,12 +27,11 @@ func environment(cmd uint32, data unsafe.Pointer) bool {
 		}
 		return videoSetPixelFormat(format)
 	case libretro.EnvironmentGetSystemDirectory:
+		fallthrough
 	case libretro.EnvironmentGetSaveDirectory:
 		libretro.SetString(data, ".")
-		return true
 	case libretro.EnvironmentShutdown:
 		window.SetShouldClose(true)
-		return true
 	case libretro.EnvironmentGetVariable:
 		variable := libretro.GetVariable(data)
 		fmt.Println("[Env]: get variable:", variable.Key)

--- a/video.go
+++ b/video.go
@@ -42,17 +42,14 @@ func videoSetPixelFormat(format uint32) bool {
 		video.pixFmt = gl.UNSIGNED_SHORT_5_5_5_1
 		video.pixType = gl.BGRA
 		video.bpp = 2
-		break
 	case libretro.PixelFormatXRGB8888:
 		video.pixFmt = gl.UNSIGNED_INT_8_8_8_8_REV
 		video.pixType = gl.BGRA
 		video.bpp = 4
-		break
 	case libretro.PixelFormatRGB565:
 		video.pixFmt = gl.UNSIGNED_SHORT_5_6_5
 		video.pixType = gl.RGB
 		video.bpp = 2
-		break
 	default:
 		log.Fatalf("Unknown pixel type %v", format)
 	}


### PR DESCRIPTION
Switch statements in go don't need the break:
https://github.com/golang/go/wiki/Switch

megacheck was upset with us.